### PR TITLE
Refines user routes and functionality

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -3,7 +3,7 @@ const { conn } = require("./src/db.js");
 const loadRoles = require("./src/helpers/loadRoles.js"); //Agrega los roles cada vez que se inicializa la base de datos
 // Syncing all the models at once.
 conn.sync({ force: false }).then(() => {
-//  loadRoles(); //Ejecuta para agregar los roles a la DB
+  //loadRoles(); //Ejecuta para agregar los roles a la DB
   server.listen(process.env.PORT || 3001, () => {
     console.log("listening at port " + process.env.PORT); // eslint-disable-line no-console
   });

--- a/api/src/helpers/userHelper.js
+++ b/api/src/helpers/userHelper.js
@@ -1,0 +1,10 @@
+const { Role, Op } = require("../db.js");
+
+module.exports = {
+  getRoleID: async (roleName) => {
+    const userRoleObject = await Role.findOne({
+      where: { name: roleName },
+    });
+    return userRoleObject.role_id;
+  },
+};

--- a/api/src/middlewares/auth.js
+++ b/api/src/middlewares/auth.js
@@ -17,6 +17,10 @@ const checkActiveUser = async (req, res, next) => {
 };
 
 //Revisa q el UID del usuario es valido
+//Responde en el caso de q la sesion no este activa (no llega a revisar el usuario)
+//Responde en el caso de q el usuario sea invalido
+//Captura y responde ante errores de ejecucion
+//Si todo esta ok, next(); y sigue a la ruta
 const checkValidUser = async (req, res, next) => {
   const token = req.headers.authorization.split(" ")[1];
   try {
@@ -27,11 +31,11 @@ const checkValidUser = async (req, res, next) => {
       if (user) {
         req.body.uid = uid;
         return next();
+      } else {
+        res.status(401).send({ message: "Invalid user" });
       }
     }
-    return res
-      .status(401)
-      .send({ message: "Invalid user or session no longer active" });
+    return res.status(401).send({ message: "Session no longer active" });
   } catch (err) {
     return res.status(500).send({ message: "Internal server error" });
   }

--- a/api/src/models/User.js
+++ b/api/src/models/User.js
@@ -10,8 +10,7 @@ const { DataTypes } = require("sequelize");
 module.exports = (sequelize) => {
   sequelize.define("User", {
     user_id: {
-      type: DataTypes.INTEGER,
-      autoIncrement: true,
+      type: DataTypes.STRING,
       primaryKey: true,
     },
     name: {

--- a/api/src/routes/users.js
+++ b/api/src/routes/users.js
@@ -1,45 +1,49 @@
 const { Router } = require("express");
 const { User, Role, Op } = require("../db.js");
+const userHelper = require("../helpers/userHelper.js");
 const axios = require("axios");
 require("dotenv").config();
 const { checkActiveUser, checkValidUser } = require("../middlewares/auth.js");
 
 const users = Router();
 
-users.get("/testRoute", async (req, res) => {
+users.get("/getUser", checkValidUser, async (req, res) => {
+  const { uid } = req.body;
   try {
-    const roles = await Role.findAll();
-    res.status(200).send(roles);
+    const user = await User.findByPk(uid);
+    res.status(200).send({ email: user.email, name: user.name });
   } catch (err) {
-    res.status(400).send(err);
+    res.status(400).send({ message: err.message });
   }
 });
 
 //Crea un usuario en nuestra DB, asignandole un rol y la referencia al UID de firebase
 users.post("/createBasicUser", checkValidUser, async (req, res) => {
   const { email, uid, name } = req.body;
+
   if (!email || !name || email === "" || name === "")
     res.status(400).send({
       message: "All creation fields must be sent, and they can't be empty",
     });
-  try {
-    const userRoleObject = await Role.findOne({
-      where: { name: "Customer" },
-    });
 
-    const newUser = await User.create({
+  try {
+    await User.create({
+      role_id: uid,
       name: name,
       email: email,
-      role_id: userRoleObject.role_id,
+      role_id: userHelper.getRoleID("Customer"),
     });
+    res
+      .status(201)
+      .send({ user: { name: name, email: email }, message: "User created" });
   } catch (err) {
-    res.status(400).send("xd");
+    res.status(400).send({ message: err.message });
   }
 });
 
 //Valida que el usuario exista, o que la sesion no haya terminado
-users.get("/validateUser", checkActiveUser, (req, res) => {
-  res.status(202).send({ message: "Usuario valido" });
+users.get("/validateActiveUser", checkActiveUser, (req, res) => {
+  res.status(202).send({ message: "Valid user" });
 });
 
 module.exports = users;


### PR DESCRIPTION
Modifica la tabla de user: el id se setea por back, usando el mismo ID de firebase (simplifica llevar los datos al front).
Termina la ruta "/createBasicUser" para crear los usuarios con el menor nivel de permisos (clientes).
Crea la ruta "/getUser" para devolverle al front el name (apodo) y el email de un usuario que loguea.
Cambia el nombre de la ruta "validateUser" a "validateActiveUser" para que sea mas claro. 